### PR TITLE
Fixing build with lv2 >= 1.18.0

### DIFF
--- a/gui/sorcer_ui.cxx
+++ b/gui/sorcer_ui.cxx
@@ -44,7 +44,7 @@ typedef struct {
   LV2UI_Controller controller;
 } SorcerGUI;
 
-static LV2UI_Handle instantiate(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle instantiate(const struct LV2UI_Descriptor * descriptor,
                 const char * plugin_uri,
                 const char * bundle_path,
                 LV2UI_Write_Function write_function,


### PR DESCRIPTION
gui/sorcer_ui.cxx:
Replacing all occurrences of _LV2UI_Descriptor with LV2UI_Descriptor as
the former has been replaced by the latter with lv2 1.18.0.