### PR TITLE
Fix build with lv2 >= 1.1.18

### DIFF
--- a/gui/sorcer_ui.cxx
+++ b/gui/sorcer_ui.cxx
@@ -44,7 +44,7 @@ typedef struct {
   LV2UI_Controller controller;
 } SorcerGUI;
 
-static LV2UI_Handle instantiate(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle instantiate(const struct LV2UI_Descriptor * descriptor,
                 const char * plugin_uri,
                 const char * bundle_path,
                 LV2UI_Write_Function write_function,


### PR DESCRIPTION
Name of the struct is gone with lv2 1.1.18. Instead use name of typedef.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>